### PR TITLE
[Refactor] Use `state` instead of global variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ tokio = { version = "^1.32", features = ["macros", "rt-multi-thread"] }
 ntex = { version = "^0.7", features = ["tokio"] }
 serde = { version = "^1.0", features = ["derive"] }
 env_logger = "^0.10"
-lazy_static = "^1.4"
-async_once = "^0.2"
 triton-client = { git = "https://github.com/octoml/triton-client-rs.git" }
 mimalloc = { version = "^0.1", default-features = false }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=planner /workspace/recipe.json .
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
-RUN cargo build --release
+RUN cargo build --release --bin server
 
 FROM alpine:latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: update format server lint
+.PHONY: update format lint build
 
 update:
 	cargo upgrade
@@ -6,8 +6,15 @@ update:
 format:
 	cargo +nightly fmt
 
-server:
-	cargo run --release --bin server
-
 lint:
 	cargo +nightly clippy
+
+build:
+	cargo run --release --bin server
+
+build-docker:
+	docker build .
+	docker run -it -p8080:8080 -p8001:8001
+
+run-example:
+	./run_client.sh

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ build:
 
 build-docker:
 	docker build . -t triton-proxy
-	docker run --rm --network=host --shm-size=2g -it -p8080:8080 triton-proxy
+
+run-docker:
+	docker run --rm --shm-size=2g -it -p8080:8080 triton-proxy
+
+run-docker-compose:
+	docker-compose up -d
 
 run-example:
 	./run_client.sh

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ build:
 	cargo run --release --bin server
 
 build-docker:
-	docker build .
-	docker run -it -p8080:8080 -p8001:8001
+	docker build . -t triton-proxy
+	docker run --rm --network=host --shm-size=2g -it -p8080:8080 triton-proxy
 
 run-example:
 	./run_client.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+  triton-server:
+    image: nvcr.io/nvidia/tritonserver:23.09-py3
+    command: bash -c "LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libtcmalloc.so.4:${LD_PRELOAD} && pip install transformers tokenizers && tritonserver --model-repository=/models"
+    volumes:
+      - C:\Users\zero\Desktop\embedding-server-triton/model_repository:/models
+    ports:
+      - 8000:8000
+      - 8001:8001
+      - 8002:8002
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+        limits:
+          memory: 8g
+    ulimits:
+      memlock: -1
+      stack: 67108864
+  proxy-server:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    depends_on:
+      - triton-server
+    image: triton-proxy
+    ports:
+      - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   triton-server:
     image: nvcr.io/nvidia/tritonserver:23.09-py3
+    restart: always
     command: bash -c "LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libtcmalloc.so.4:${LD_PRELOAD} && pip install transformers tokenizers && tritonserver --model-repository=/models"
     volumes:
       - C:\Users\zero\Desktop\embedding-server-triton/model_repository:/models
@@ -22,12 +23,16 @@ services:
     ulimits:
       memlock: -1
       stack: 67108864
-  proxy-server:
+  proxy:
     build:
       context: ./
       dockerfile: Dockerfile
     depends_on:
       - triton-server
     image: triton-proxy
+    restart: always
     ports:
       - 8080:8080
+    environment:
+      TRITON_SERVER_ADDRESS: triton-server
+      TRITON_SERVER_PORT_GRPC: 8001

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -1,6 +1,6 @@
 // todo : move to docker secret or env wherever
 pub const SERVER_PORT: u16 = 8080;
-pub const TRITON_SERVER_URL: &str = "http://127.0.0.1:8001";
+pub const TRITON_SERVER_URL: &str = "http://triton-server:8001";
 pub const MODEL_VERSION: &str = "1";
 pub const MODEL_NAME: &str = "model";
 pub const INPUT_NAME: &str = "text";

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1,20 +1,23 @@
 pub mod embedding;
 
-use ntex::web::types::Json;
+use ntex::web::types::{Json, State};
 use ntex::web::{post, Error, HttpResponse};
 
 use crate::endpoints::embedding::get_embedding;
 use crate::models::{EmbeddingResponse, QueryRequest};
 
 #[post("/v1/embedding")]
-pub async fn get_v1_embedding(requests: Json<Vec<QueryRequest>>) -> Result<HttpResponse, Error> {
+pub async fn get_v1_embedding(
+    requests: Json<Vec<QueryRequest>>,
+    client: State<triton_client::Client>,
+) -> Result<HttpResponse, Error> {
     let queries: Vec<String> = requests
         .into_inner()
         .into_iter()
         .map(|req: QueryRequest| req.query)
         .collect();
 
-    let responses: Vec<EmbeddingResponse> = get_embedding(queries).await;
+    let responses: Vec<EmbeddingResponse> = get_embedding(queries, client).await;
 
     Ok(HttpResponse::Ok().json(&responses))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> std::io::Result<()> {
             .service(health_check)
             .service(get_v1_embedding)
     })
-    .bind(("127.0.0.1", SERVER_PORT))?
+    .bind(("0.0.0.0", SERVER_PORT))?
     .run()
     .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use ntex::web::{get, App, HttpResponse, HttpServer, Responder};
 
-use crate::constants::SERVER_PORT;
+use crate::constants::{SERVER_PORT, TRITON_SERVER_URL};
 use crate::endpoints::get_v1_embedding;
 
 mod constants;
@@ -17,11 +17,20 @@ async fn health_check() -> impl Responder {
 
 #[ntex::main]
 async fn main() -> std::io::Result<()> {
-    std::env::set_var("RUST_LOG", "error");
+    std::env::set_var("RUST_LOG", "info");
     env_logger::init();
 
-    HttpServer::new(|| App::new().service(health_check).service(get_v1_embedding))
-        .bind(("127.0.0.1", SERVER_PORT))?
-        .run()
+    let client: triton_client::Client = triton_client::Client::new(TRITON_SERVER_URL, None)
         .await
+        .unwrap();
+
+    HttpServer::new(move || {
+        App::new()
+            .state(client.clone())
+            .service(health_check)
+            .service(get_v1_embedding)
+    })
+    .bind(("127.0.0.1", SERVER_PORT))?
+    .run()
+    .await
 }


### PR DESCRIPTION
## Change Log

* use `state` instead of global variable
* remove `async_once`, `lazy_static` crates
* fix Dockerfile
